### PR TITLE
Add unit and integration tests for Fiber app

### DIFF
--- a/internal/user/handler_test.go
+++ b/internal/user/handler_test.go
@@ -1,0 +1,81 @@
+package user
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func TestGetUsers(t *testing.T) {
+	app := fiber.New()
+	app.Get("/users", GetUsers)
+
+	req := httptest.NewRequest("GET", "/users", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	defer resp.Body.Close()
+
+	var users []User
+	if err := json.NewDecoder(resp.Body).Decode(&users); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(users))
+	}
+}
+
+func TestGetUser(t *testing.T) {
+	app := fiber.New()
+	app.Get("/users/:id", GetUser)
+
+	req := httptest.NewRequest("GET", "/users/1", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	defer resp.Body.Close()
+
+	var user User
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if user.ID != 1 {
+		t.Fatalf("expected user ID 1, got %d", user.ID)
+	}
+}
+
+func TestCreateUser(t *testing.T) {
+	app := fiber.New()
+	app.Post("/users", CreateUser)
+
+	payload := `{"id":3,"name":"鈴木","age":40}`
+	req := httptest.NewRequest("POST", "/users", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected status %d, got %d", fiber.StatusOK, resp.StatusCode)
+	}
+	defer resp.Body.Close()
+
+	var user User
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if user.Name != "鈴木" || user.Age != 40 {
+		t.Fatalf("unexpected user data: %+v", user)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,8 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-func main() {
+// SetupApp configures routes and returns a Fiber application instance.
+func SetupApp() *fiber.App {
 	app := fiber.New()
 
 	app.Use(prometheus.PrometheusMiddleware())
@@ -26,5 +27,10 @@ func main() {
 
 	app.Get("/metrics", prometheus.NewMetricsHandler())
 
+	return app
+}
+
+func main() {
+	app := SetupApp()
 	log.Fatal(app.Listen(":3000"))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestAppRunning verifies that the Fiber app can start and respond to a request.
+func TestAppRunning(t *testing.T) {
+	app := SetupApp()
+
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		if err := app.Listener(ln); err != nil && err != http.ErrServerClosed {
+			t.Errorf("app.Listener error: %v", err)
+		}
+	}()
+
+	addr := ln.Addr().(*net.TCPAddr)
+	time.Sleep(10 * time.Millisecond)
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/", addr.Port))
+	if err != nil {
+		t.Fatalf("failed to get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
+	if err := app.Shutdown(); err != nil {
+		t.Fatalf("app.Shutdown error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- refactor main to expose `SetupApp` for tests
- add unit tests for user handlers
- add integration test ensuring app responds when started
- close HTTP response bodies in tests to prevent hangs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b3ac1e62c48320bbc3d716e71d446f